### PR TITLE
Update metrics-api-service.yaml

### DIFF
--- a/charts/metrics-server/Chart.yaml
+++ b/charts/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.6
 description: DEPRECATED - Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.11.4
+version: 2.11.5
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/charts/metrics-server/templates/metrics-api-service.yaml
+++ b/charts/metrics-server/templates/metrics-api-service.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apiService.create -}}
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io


### PR DESCRIPTION
Patched deprecated api
`apiregistration.k8s.io/v1beta1 APIService is deprecated in v1.19+, unavailable in v1.22+; use apiregistration.k8s.io/v1 APIService`